### PR TITLE
[Refactor/#28]페이지 디자인 디테일 수정 

### DIFF
--- a/src/components/Chart/Chart.css
+++ b/src/components/Chart/Chart.css
@@ -4,8 +4,3 @@
   padding: 30px;
   margin-right: 10px;
 }
-
-#chart-container {
-  width: 100%;
-  height: 100%;
-}

--- a/src/components/Chart/Chart.css
+++ b/src/components/Chart/Chart.css
@@ -1,3 +1,4 @@
+/* src/components/Chart/Chart.css */
 .chart-wrapper {
   width: 90%; 
   height: 100%;

--- a/src/components/Chart/Chart.css
+++ b/src/components/Chart/Chart.css
@@ -1,4 +1,3 @@
-/* src/components/Chart/Chart.css */
 .chart-wrapper {
   width: 90%; 
   height: 100%;

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -1,3 +1,5 @@
+// src/components/Chart/Chart.jsx
+
 import React, { useEffect } from 'react';
 import Highcharts from 'highcharts';
 import Exporting from 'highcharts/modules/exporting';
@@ -84,23 +86,26 @@ const Chart = ({ onSliceClick, selectedMode }) => {
       };
     })(Highcharts);
   
+    // 차트 생성
     const chart = Highcharts.chart('chart-container', {
       chart: {
         type: 'pie',
         backgroundColor: 'transparent',
-        reflow: false,
+        // 1) 여기서 reflow를 true로 바꿔주세요.
+        reflow: true, 
         events: {
           load: function () {
             const chart = this;
-            chart.renderer.label(
-              'Total<br>42',
-              chart.plotLeft + chart.plotWidth / 2,
-              chart.plotTop + chart.plotHeight / 2 - 30,
-              null,
-              null,
-              null,
-              true
-            )
+            chart.renderer
+              .label(
+                'Total<br>42',
+                chart.plotLeft + chart.plotWidth / 2,
+                chart.plotTop + chart.plotHeight / 2 - 30,
+                null,
+                null,
+                null,
+                true
+              )
               .css({
                 color: '#000',
                 fontSize: '24px',
@@ -110,12 +115,9 @@ const Chart = ({ onSliceClick, selectedMode }) => {
               .attr({ align: 'center' })
               .add()
               .toFront();
-            // 최초 애니메이션 완료 후, 애니메이션 함수를 무효화하여 이후 호출 시 효과가 나타나지 않도록 함.
-            Highcharts.seriesTypes.pie.prototype.animate = function (init) {
-              if (init) {
-                this.points.forEach(point => point.graphic.attr({ opacity: 0 }));
-              }
-            };
+            
+            // 최초 로드 후에는 애니메이션 함수를 비워서 재호출되지 않도록 함
+            Highcharts.seriesTypes.pie.prototype.animate = function () {};
           }
         }
       },
@@ -143,7 +145,6 @@ const Chart = ({ onSliceClick, selectedMode }) => {
                 if (onSliceClick) {
                   onSliceClick(this.name);
                 }
-                // 클릭 시에는 무효화된 animate 함수로 인해 애니메이션 없이 opacity를 즉시 변경
                 this.series.points.forEach(pt => {
                   pt.graphic.attr({ opacity: pt === this ? 1 : 0.3 });
                 });
@@ -169,8 +170,8 @@ const Chart = ({ onSliceClick, selectedMode }) => {
         }
       ]
     });
-  }, [onSliceClick]);
-  
+  }, []);
+
   return (
     <div className="chart-wrapper">
       <div className="chart-inner">

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -1,5 +1,3 @@
-// src/components/Chart/Chart.jsx
-
 import React, { useEffect } from 'react';
 import Highcharts from 'highcharts';
 import Exporting from 'highcharts/modules/exporting';
@@ -21,7 +19,7 @@ const Chart = ({ onSliceClick, selectedMode }) => {
   useEffect(() => {
     // 원래 animate 함수(초기 애니메이션용)를 저장합니다.
     const originalAnimate = Highcharts.seriesTypes.pie.prototype.animate;
-    
+
     (function (H) {
       H.seriesTypes.pie.prototype.animate = function (init) {
         const series = this,
@@ -29,25 +27,25 @@ const Chart = ({ onSliceClick, selectedMode }) => {
           points = series.points,
           { animation } = series.options,
           { startAngleRad } = series;
-  
+
         function fanAnimate(point, startAngleRad) {
           const graphic = point.graphic,
             args = point.shapeArgs;
-  
+
           if (graphic && args) {
             graphic
               .attr({
                 start: startAngleRad,
                 end: startAngleRad,
-                opacity: 1
+                opacity: 1,
               })
               .animate(
                 {
                   start: args.start,
-                  end: args.end
+                  end: args.end,
                 },
                 {
-                  duration: animation.duration / points.length
+                  duration: animation.duration / points.length,
                 },
                 function () {
                   if (points[point.index + 1]) {
@@ -58,7 +56,7 @@ const Chart = ({ onSliceClick, selectedMode }) => {
                       { opacity: 1 },
                       void 0,
                       function () {
-                        points.forEach(p => {
+                        points.forEach((p) => {
                           p.opacity = 1;
                         });
                         series.update({ enableMouseTracking: true }, false);
@@ -66,9 +64,9 @@ const Chart = ({ onSliceClick, selectedMode }) => {
                           plotOptions: {
                             pie: {
                               innerSize: '40%',
-                              borderRadius: 8
-                            }
-                          }
+                              borderRadius: 8,
+                            },
+                          },
                         });
                       }
                     );
@@ -77,22 +75,21 @@ const Chart = ({ onSliceClick, selectedMode }) => {
               );
           }
         }
-  
+
         if (init) {
-          points.forEach(point => (point.opacity = 0));
+          points.forEach((point) => (point.opacity = 0));
         } else {
           fanAnimate(points[0], startAngleRad);
         }
       };
     })(Highcharts);
-  
+
     // 차트 생성
     const chart = Highcharts.chart('chart-container', {
       chart: {
         type: 'pie',
         backgroundColor: 'transparent',
-        // 1) 여기서 reflow를 true로 바꿔주세요.
-        reflow: true, 
+        reflow: true,
         events: {
           load: function () {
             const chart = this;
@@ -110,23 +107,23 @@ const Chart = ({ onSliceClick, selectedMode }) => {
                 color: '#000',
                 fontSize: '24px',
                 fontWeight: 'bold',
-                textAlign: 'center'
+                textAlign: 'center',
               })
               .attr({ align: 'center' })
               .add()
               .toFront();
-            
+
             // 최초 로드 후에는 애니메이션 함수를 비워서 재호출되지 않도록 함
             Highcharts.seriesTypes.pie.prototype.animate = function () {};
-          }
-        }
+          },
+        },
       },
       title: { text: '' },
       subtitle: { text: '' },
       tooltip: {
         headerFormat: '',
         pointFormat:
-          '<span style="color:{point.color}">\u25cf</span> {point.name}: <b>{point.percentage:.1f}%</b>'
+          '<span style="color:{point.color}">\u25cf</span> {point.name}: <b>{point.percentage:.1f}%</b>',
       },
       accessibility: { point: { valueSuffix: '%' } },
       plotOptions: {
@@ -137,38 +134,40 @@ const Chart = ({ onSliceClick, selectedMode }) => {
           dataLabels: {
             enabled: true,
             format: '<b>{point.name}</b><br>{point.percentage}%',
-            distance: 20
+            distance: 20,
           },
           point: {
             events: {
-              click: function() {
+              click: function () {
                 if (onSliceClick) {
                   onSliceClick(this.name);
                 }
-                this.series.points.forEach(pt => {
-                  pt.graphic.attr({ opacity: pt === this ? 1 : 0.3 });
+                const selectedPoint = this;
+                this.series.points.forEach((pt) => {
+                  const isSelected = pt === selectedPoint;
+                  pt.graphic.attr({ opacity: isSelected ? 1 : 0.3 });
                 });
-              }
-            }
-          }
-        }
+              },
+            },
+          },
+        },
       },
       exporting: { enabled: false },
       credits: { enabled: false },
       series: [
         {
           enableMouseTracking: false,
-          animation: { duration: 2000 },
+          animation: { duration: 1500 },
           colorByPoint: true,
           data: [
             { name: 'CLEAN', y: 21.3, color: '#9E9E9E' },
             { name: 'OPTIMIZE', y: 18.7, color: '#4CAF50' },
             { name: 'NEWBIE', y: 20.2, color: '#2196F3' },
             { name: 'STUDY', y: 14.2, color: '#FFC107' },
-            { name: 'BASIC', y: 25.6, color: '#FF5722' }
-          ]
-        }
-      ]
+            { name: 'BASIC', y: 25.6, color: '#FF5722' },
+          ],
+        },
+      ],
     });
   }, []);
 

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -17,7 +17,6 @@ if (Accessibility && typeof Accessibility === 'function') {
 
 const Chart = ({ onSliceClick, selectedMode }) => {
   useEffect(() => {
-    // 원래 animate 함수(초기 애니메이션용)를 저장합니다.
     const originalAnimate = Highcharts.seriesTypes.pie.prototype.animate;
 
     (function (H) {
@@ -84,7 +83,6 @@ const Chart = ({ onSliceClick, selectedMode }) => {
       };
     })(Highcharts);
 
-    // 차트 생성
     const chart = Highcharts.chart('chart-container', {
       chart: {
         type: 'pie',
@@ -113,7 +111,6 @@ const Chart = ({ onSliceClick, selectedMode }) => {
               .add()
               .toFront();
 
-            // 최초 로드 후에는 애니메이션 함수를 비워서 재호출되지 않도록 함
             Highcharts.seriesTypes.pie.prototype.animate = function () {};
           },
         },
@@ -123,7 +120,7 @@ const Chart = ({ onSliceClick, selectedMode }) => {
       tooltip: {
         headerFormat: '',
         pointFormat:
-          '<span style="color:{point.color}">\u25cf</span> {point.name}: <b>{point.percentage:.1f}%</b>',
+          '<span style="color:{point.color}">●</span> {point.name}: <b>{point.percentage:.1f}%</b>',
       },
       accessibility: { point: { valueSuffix: '%' } },
       plotOptions: {
@@ -142,11 +139,6 @@ const Chart = ({ onSliceClick, selectedMode }) => {
                 if (onSliceClick) {
                   onSliceClick(this.name);
                 }
-                const selectedPoint = this;
-                this.series.points.forEach((pt) => {
-                  const isSelected = pt === selectedPoint;
-                  pt.graphic.attr({ opacity: isSelected ? 1 : 0.3 });
-                });
               },
             },
           },

--- a/src/components/ModeselectButton/Modeselectbutton.css
+++ b/src/components/ModeselectButton/Modeselectbutton.css
@@ -1,11 +1,11 @@
 .modeselect-button {
-  min-width: 200px; /* 버튼 최소 너비 */
-  min-height: 120px; /* 버튼 최소 높이 */
+  min-width: 260px; /* 버튼 최소 너비 */
+  min-height: 140px; /* 버튼 최소 높이 */
   width: 12vw; /* 화면 너비의 12% */
   height: 12vh; /* 화면 높이의 12% */
   max-width: 500px; /* 버튼 최대 너비 */
   max-height: 300px; /* 버튼 최대 높이 */
-  background-color: #ffffff;
+  background-color: #F3F3F3;
   border: none;
   border-radius: 1vw; /* 둥근 모서리 크기 조정 */
   cursor: pointer;
@@ -13,8 +13,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  margin: 0.5vw; /* 버튼 간격 */
-  box-shadow: 0 0.6vh 0.1vh rgba(0, 0, 0, 1);
+  box-shadow: 0 0.4vh 0.1vh rgba(0, 0, 0, 1);
   transition: background-color 0.3s ease, transform 0.2s ease;
   font-size: clamp(16px, 2vw, 24px); /* 동적 폰트 크기 */
 }

--- a/src/components/Reviews/Reviews.css
+++ b/src/components/Reviews/Reviews.css
@@ -1,17 +1,16 @@
 .reviews-container {
-    width: 800px;
-    height: 70%; /* 리뷰리스트 영역의 세로 길이의 70% */
+    width: 850px;
+    max-height: 79%; /* 한화면에 리스트 4개 보이게 할려면 65%로 설정 */
     overflow-y: auto;
     overflow-x: hidden; /* 가로 스크롤 제거 */
-    margin-bottom: -30px;
-    margin-top: 23px;
+    margin-top: 40px;
     margin-left: 8px;
 }
 
 .review-item {
     display: flex;
     flex-direction: column;
-    width: 775px;
+    width: 830px;
     min-height: 57px;
     border: 1px solid #ccc;
     border-radius: 15px;

--- a/src/components/Reviews/Reviews.css
+++ b/src/components/Reviews/Reviews.css
@@ -1,4 +1,3 @@
-/* src/components/Reviews/Reviews.css */
 .reviews-container {
     width: 850px;
     max-height: 79%; /* 한화면에 리스트 4개 보이게 할려면 65%로 설정 */

--- a/src/components/Reviews/Reviews.css
+++ b/src/components/Reviews/Reviews.css
@@ -1,3 +1,4 @@
+/* src/components/Reviews/Reviews.css */
 .reviews-container {
     width: 850px;
     max-height: 79%; /* 한화면에 리스트 4개 보이게 할려면 65%로 설정 */
@@ -19,6 +20,7 @@
     box-sizing: border-box;
     background-color: #F3F3F3; /* 배경색 설정 */
     font-size: 15px;
+    box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.25);
 }
 
 .review-summary {

--- a/src/components/Reviews/Reviews.jsx
+++ b/src/components/Reviews/Reviews.jsx
@@ -1,4 +1,3 @@
-//src/components/Reviews/Reviews.jsx
 import React from 'react';
 import './Reviews.css';
 

--- a/src/components/Reviews/Reviews.jsx
+++ b/src/components/Reviews/Reviews.jsx
@@ -1,49 +1,135 @@
 import React from 'react';
 import './Reviews.css';
 
+//더미데이터
 const dummyReviews = [
   { 
     id: 1, 
     mode: 'CLEAN', 
-    link: "Feat/#68 수정하기api 반환값에 origin_url추가", 
+    link: "[feat/#3] 알림 버튼 구현", 
     date: '2023.01.01', 
     content: "코드 가독성이 우수하며, 함수 이름이 직관적입니다." 
   },
   { 
     id: 2, 
     mode: 'OPTIMIZE', 
-    link: "Feat/#48 modified_html 함수 Celary로 비동기", 
+    link: "[feat/#6] 서치 바 제작", 
     date: '2023.01.02', 
     content: "비동기 처리 부분이 잘 구현되었으나, 몇몇 매직 넘버에 개선 여지가 있습니다." 
   },
   { 
     id: 3, 
     mode: 'NEWBIE', 
-    link: "Feat/#68 수정하기api 반환값에 origin_url추가", 
+    link: "[feat/#7] 서치 바(Alternative Version) 제작 ", 
     date: '2023.01.03', 
     content: "초보자도 이해하기 쉬운 코드지만, 주석 및 문서화가 부족합니다." 
   },
   { 
     id: 4, 
     mode: 'STUDY', 
-    link: "Feat/#51 검토결과 - tasks.py 비동기 처리추가", 
+    link: "[feat/#4]: 모드선택 버튼 제작", 
     date: '2023.01.04', 
     content: "전체적인 코드 구조는 적절하나, 내부 로직이 복잡하여 분리하면 더 좋을 것 같습니다." 
   },
   { 
     id: 5, 
     mode: 'BASIC', 
-    link: "Feat/#68 수정하기api 반환값에 origin_url추가", 
+    link: "[feat/#10] 모달창 구현", 
     date: '2023.01.05', 
     content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
   },
+  { 
+    id: 6, 
+    mode: 'STUDY', 
+    link: "[feat/#14] 사이드바 (+버튼) 구현", 
+    date: '2023.01.05', 
+    content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
+  },
+  { 
+    id: 7, 
+    mode: 'STUDY', 
+    link: "[feat/#12] 리포트 리스트 컴포넌트 구현", 
+    date: '2023.01.05', 
+    content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
+  },
+  { 
+    id: 8, 
+    mode: 'OPTIMIZE', 
+    link: "[docs/#19] 파일 경로 수정 및 라우팅 설정", 
+    date: '2023.01.05', 
+    content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
+  },
+  { 
+    id: 9, 
+    mode: 'OPTIMIZE', 
+    link: "Design/#21 리포지토리 페이지 구현", 
+    date: '2023.01.05', 
+    content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
+  },
+  { 
+    id: 10, 
+    mode: 'OPTIMIZE', 
+    link: "[feat/#18] history페이지 구현", 
+    date: '2023.01.05', 
+    content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
+  },
+  { 
+    id: 11, 
+    mode: 'CLEAN', 
+    link: "[refactor/#41] API명세서에 맞춘 코드 수정", 
+    date: '2023.01.05', 
+    content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
+  },
+  { 
+    id: 12, 
+    mode: 'CLEAN', 
+    link: "[feat/#38] Report에 사용된 PR 모드 확인 기능 추가 및 이전 코드 보완", 
+    date: '2023.01.05', 
+    content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
+  },
+  { 
+    id: 13, 
+    mode: 'NEWBIE', 
+    link: "[feat] 전체 PR 모드 카테고리 통계 조회, 리팩토링", 
+    date: '2023.01.05', 
+    content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
+  },
+  { 
+    id: 14, 
+    mode: 'OPTIMIZE', 
+    link: "[docs/#19] 파일 경로 수정 및 라우팅 설정", 
+    date: '2023.01.05', 
+    content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
+  },
+  { 
+    id: 15, 
+    mode: 'OPTIMIZE', 
+    link: "[docs/#19] 파일 경로 수정 및 라우팅 설정", 
+    date: '2023.01.05', 
+    content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
+  },
+  { 
+    id: 16, 
+    mode: 'OPTIMIZE', 
+    link: "[docs/#19] 파일 경로 수정 및 라우팅 설정", 
+    date: '2023.01.05', 
+    content: "기본적인 코드 패턴은 잘 따르고 있으나, 최적화 측면에서 개선할 부분이 보입니다." 
+  }
+  
 ];
 
-const Reviews = ({ onReviewClick, selectedMode }) => {
-  // 만약 selectedMode가 설정되어 있으면 필터링, 아니면 전체 출력
-  const filteredReviews = selectedMode 
-    ? dummyReviews.filter(review => review.mode === selectedMode)
-    : dummyReviews;
+
+const Reviews = ({ onReviewClick, selectedMode, searchTerm }) => {
+  const filteredReviews = dummyReviews.filter(review => {
+    // 모드 필터링
+    const matchesMode =
+      !selectedMode || selectedMode === '' || review.mode === selectedMode;
+    // link 속성에서 검색어 필터링 (대소문자 구분 없이)
+    const matchesSearch =
+      !searchTerm || review.link.toLowerCase().includes(searchTerm.toLowerCase());
+    
+    return matchesMode && matchesSearch;
+  });
 
   return (
     <div className="reviews-container">
@@ -55,10 +141,18 @@ const Reviews = ({ onReviewClick, selectedMode }) => {
           style={{ cursor: 'pointer' }}
         >
           <div className="review-summary">
-            <div className={`review-mode ${review.mode.toLowerCase()}`}>{review.mode}</div>
-            <div className="review-link">{review.link}</div>
-            <div className="review-date">{review.date}</div>
-            <div className="review-arrow">→</div>
+            <div className={`review-mode ${review.mode.toLowerCase()}`}>
+              {review.mode}
+            </div>
+            <div className="review-link">
+              {review.link}
+            </div>
+            <div className="review-date">
+              {review.date}
+            </div>
+            <div className="review-arrow">
+              →
+            </div>
           </div>
         </div>
       ))}

--- a/src/components/Reviews/Reviews.jsx
+++ b/src/components/Reviews/Reviews.jsx
@@ -1,3 +1,4 @@
+//src/components/Reviews/Reviews.jsx
 import React from 'react';
 import './Reviews.css';
 

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -1,5 +1,4 @@
-html,
-body {
+html, body {
   margin: 0;
   padding: 0;
   height: 100%;
@@ -10,9 +9,9 @@ body {
 }
 
 .sidebar {
-  position: fixed; /* 고정 */
-  top: 0; /* 상단에 */
-  left: 0; /* 왼쪽 끝에 */
+  position: fixed;        /* 고정 */
+  top: 0;                 /* 상단에 */
+  left: 0;                /* 왼쪽 끝에 */
   width: 15%;
   min-width: 300px;
   height: 100vh;
@@ -22,7 +21,7 @@ body {
   flex-direction: column;
   align-items: center;
   padding-top: 10%;
-  z-index: 1000; /* 다른 콘텐츠보다 위에 보이도록 */
+  z-index: 1000;          /* 다른 콘텐츠보다 위에 보이도록 */
 }
 
 .sidebar-rounded-top {
@@ -32,11 +31,7 @@ body {
   width: 40px;
   height: 40px;
   background-color: #091904;
-  -webkit-mask: radial-gradient(
-    circle at bottom right,
-    transparent 50%,
-    black 100%
-  );
+  -webkit-mask: radial-gradient(circle at bottom right, transparent 50%, black 100%);
   mask: radial-gradient(circle at bottom right, transparent 50%, black 51%);
   -webkit-mask-composite: exclude;
   mask-composite: exclude;

--- a/src/components/SidebarButton/SidebarButton.css
+++ b/src/components/SidebarButton/SidebarButton.css
@@ -1,38 +1,34 @@
-//SidebarButton.css
-
 .sidebar-button {
-  width: 60%; /* 부모 요소(사이드바)의 폭에 맞춤 */
-  height: auto;
-  padding: 0.3vh;
-  margin: 10px 0;
-  background-color: #091904;
-  color: white;
-  text-align: center;
-  text-decoration: none;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-  transition:
-    background-color 0.3s ease,
-    transform 0.2s ease;
-  position: relative;
-  font-size: calc(1rem + 0.5vw); /* 사이드바 크기에 따라 텍스트 크기 조정 */
+    width: 60%; /* 부모 요소(사이드바)의 폭에 맞춤 */
+    height: auto;
+    padding: 0.3vh;
+    margin: 10px 0;
+    background-color: #091904;
+    color: white;
+    text-align: center;
+    text-decoration: none;
+    border: none;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+    position: relative;
+    font-size: calc(1rem + 0.5vw); /* 사이드바 크기에 따라 텍스트 크기 조정 */
 }
 
 .sidebar-button:hover {
-  background-color: #133508;
-  transform: translateY(-2px);
+    background-color: #133508;
+    transform: translateY(-2px);
 }
 
 .sidebar-button:active {
-  background-color: #aef060;
-  transform: translateY(1px) scale(0.98);
+    background-color: #AEF060;
+    transform: translateY(1px) scale(0.98);
 }
 
 .sidebar-button.active {
-  background-color: #aef060;
-  font-weight: bold;
-  cursor: default;
-  color: #3d3c3c;
-  transform: scale(1.03);
+    background-color: #AEF060;
+    font-weight: bold;
+    cursor: default;
+    color: #3D3C3C;
+    transform: scale(1.03);
 }

--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -102,7 +102,7 @@
   background-color: #ffffff;
   padding: 0;
   border-radius: 1vw;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.6);
+  box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.25);
   min-width: 400px; /* 차트 최소 너비 */
   height: 40vh;
   margin: 0% 0% 0% 0%;
@@ -120,7 +120,7 @@
   align-items: center;
   background-color: #ffffff;
   border-radius: 15px;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.6);
+  box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.25);
   padding: 20px;
   width: 30vw; /* 전체 컨테이너 너비 */
   height: 40vh; /* 전체 컨테이너 높이 */

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -52,7 +52,6 @@ const Dashboard = () => {
       { date: "2025-01-13", grade: "S" },
       { date: "2025-01-14", grade: "S" },
     ],
-    //A,B,D,S,F,G
     Optimize: [
       { date: "2025-01-09", grade: "F" },
       { date: "2025-01-10", grade: "D" },

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -37,25 +37,45 @@ const Dashboard = () => {
 
   const initialData = {
     Basic: [
-      { date: "2025-01-10", grade: "A" },
+      { date: "2025-01-09", grade: "A" },
+      { date: "2025-01-10", grade: "D" },
       { date: "2025-01-11", grade: "B" },
-      { date: "2025-01-12", grade: "A" },
+      { date: "2025-01-12", grade: "F" },
+      { date: "2025-01-13", grade: "A" },
+      { date: "2025-01-14", grade: "S" },
     ],
     "Clean Code": [
-      { date: "2025-01-10", grade: "C" },
+      { date: "2025-01-09", grade: "A" },
+      { date: "2025-01-10", grade: "D" },
       { date: "2025-01-11", grade: "B" },
+      { date: "2025-01-12", grade: "A" },
+      { date: "2025-01-13", grade: "S" },
+      { date: "2025-01-14", grade: "S" },
     ],
+    //A,B,D,S,F,G
     Optimize: [
-      { date: "2025-01-11", grade: "A" },
-      { date: "2025-01-12", grade: "S" },
+      { date: "2025-01-09", grade: "F" },
+      { date: "2025-01-10", grade: "D" },
+      { date: "2025-01-11", grade: "B" },
+      { date: "2025-01-12", grade: "A" },
+      { date: "2025-01-13", grade: "E" },
+      { date: "2025-01-14", grade: "S" },
     ],
     Newbie: [
-      { date: "2025-01-11", grade: "A" },
-      { date: "2025-01-12", grade: "F" },
+      { date: "2025-01-09", grade: "F" },
+      { date: "2025-01-10", grade: "E" },
+      { date: "2025-01-11", grade: "B" },
+      { date: "2025-01-12", grade: "A" },
+      { date: "2025-01-13", grade: "S" },
+      { date: "2025-01-14", grade: "S" },
     ],
     Study: [
-      { date: "2025-01-11", grade: "B" },
-      { date: "2025-01-12", grade: "C" },
+      { date: "2025-01-09", grade: "B" },
+      { date: "2025-01-10", grade: "D" },
+      { date: "2025-01-11", grade: "F" },
+      { date: "2025-01-12", grade: "A" },
+      { date: "2025-01-13", grade: "S" },
+      { date: "2025-01-14", grade: "B" },
     ],
   };
 
@@ -92,7 +112,7 @@ const Dashboard = () => {
 
   useEffect(() => {
     const processData = (modeData) => {
-      const allDates = ["2025-01-10", "2025-01-11", "2025-01-12"];
+      const allDates = ["2025-01-09","2025-01-10", "2025-01-11", "2025-01-12","2025-01-13","2025-01-14"];
       return allDates.map((date) => {
         const entry = modeData.find((d) => d.date === date);
         return {

--- a/src/pages/History.css
+++ b/src/pages/History.css
@@ -1,112 +1,110 @@
-/* src/pages/History.css */
 /* History 페이지 전체 컨테이너 */
 .history-container {
     position: relative;
-     width: 100%;
+    width: 100%;
     height: 100vh;
     display: flex;
     flex-direction: column;
 }
-  
-/* 페이지 상단에 History 타이틀 위치 (더 위쪽으로) */
+
+/* 페이지 상단에 History 타이틀 위치 */
 .pageName {
     position: absolute;
-    top: -10px;    
+    top: -10px;
     left: 50px;
     font-size: 40px;
     margin: 0;
 }
-  
+
 /* 내용 전체를 감싸는 래퍼(왼쪽, 오른쪽 영역) */
 .content-wrapper {
     display: flex;
-    height: 100%;
-    margin-top: 80px;  /* 페이지 타이틀 아래 공간 확보 */
+    height: calc(100% - 80px); /* 페이지 타이틀 아래 공간 확보 */
+    margin-top: 80px;
     padding: 20px;
+    box-sizing: border-box;
+    overflow: hidden; /* 스크롤이 콘텐츠를 밀지 않도록 설정 */
 }
-  
-/* 왼쪽 영역: 전체 가로의 60% */
+
+/* 왼쪽 영역 */
 .left-container {
     width: 60%;
     height: 100%;
     display: flex;
     flex-direction: column;
-    gap: 20px;   /* 영역 사이 간격 축소 */
+    gap: 20px;
     padding: 20px;
     box-sizing: border-box;
+    overflow: hidden;
 }
-  
-/* 차트 영역: 왼쪽 영역의 상단 40% 높이 (크기는 그대로) */
+
+/* 차트 영역 */
 .chart-box {
     width: 100%;
-    height: 49%;  /* gap과의 조정을 위해 약간 축소 */
-    border: 1px solid #ccc;
+    height: 50%;
     position: relative;
     padding: 10px;
     box-sizing: border-box;
     box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.25);
     border-radius: 20px;
-    margin-bottom: 5px;
 }
-  
-/* 차트 내부: 위치 조절용 컨테이너 */
+
 .chart-inner {
-    width: 100%;
-    height: 100%;
+    width: 97%;
+    height: 97%;
     margin-left: -120px;
-    margin-top: 20px;
+    margin-top: 2px;
 }
-  
-/* 리뷰리스트 영역: 왼쪽 영역의 하단 40% 높이 */
+
+/* 리뷰리스트 영역 */
 .reviewList-box {
     width: 100%;
-    height: 49%;   /* gap과의 조정을 위해 약간 축소 */
-    border: 1px solid #ccc;
+    height: 48%;
     position: relative;
     padding: 10px;
     box-sizing: border-box;
     box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.25);
     border-radius: 20px;
+    overflow: hidden;
 }
-  
-/* 서치바 컨테이너 (리뷰리스트 상단에 위치) */
+
+/* 서치바 컨테이너 */
 .searchbar-container {
     margin-top: 5px;
     margin-left: 335px;
     margin-bottom: -5px;
 }
-  
-/* 오른쪽 영역: 전체 가로의 40% */
+
+/* 오른쪽 영역 */
 .right-container {
     width: 40%;
-    height: 98%;
+    height: 100%;
     padding: 10px;
     box-sizing: border-box;
     display: flex;
     align-items: flex-start;
     justify-content: center;
-    margin-top: 8px;
 }
-  
-/* 리뷰내용 영역: 오른쪽 영역 내 높이 80% (가로 100% 사용) */
+
+/* 리뷰내용 영역 */
 .reviewDetails-box {
     width: 100%;
     height: 100%;
-    border: 1px solid #ccc;
     position: relative;
     padding: 10px;
     box-sizing: border-box;
     box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.25);
     border-radius: 20px;
     background-color: #F3F3F3;
+    overflow: hidden;
 }
 
-.review-detail-text{
+.review-detail-text {
     text-align: left;
     margin-left: 20px;
     margin-top: 100px;
 }
-  
+
 /* 각 영역의 상단에 제목 텍스트 */
 .box-title {
     position: absolute;
@@ -117,25 +115,25 @@
     font-weight: bold;
     z-index: 1000;
 }
-  
+
 /* 차트 영역 오른쪽에 세로 한 줄로 범례 박스들을 배치 */
 .chart-legend {
     position: absolute;
-    top: 100px;
+    top: 120px;
     right: 110px;
     display: flex;
     flex-direction: column;
     gap: 20px;
 }
-  
-/* 범례 컨테이너: 박스와 오른쪽 라벨을 함께 포함 */
+
+/* 범례 컨테이너 */
 .legend-container {
     display: flex;
     align-items: center;
-    gap: 10px;  /* 박스와 오른쪽 라벨 간 간격 */
+    gap: 10px;
 }
-  
-/* 범례 박스(legend-item) 스타일 */
+
+/* 범례 박스 스타일 */
 .legend-item {
     display: flex;
     align-items: center;
@@ -146,13 +144,86 @@
     padding: 5px;
     box-sizing: border-box;
     font-size: 15px;
-    color: #fff; /* 텍스트 색상을 흰색으로 */
+    color: #fff;
     text-align: center;
 }
-  
-/* 범례 오른쪽 라벨 (박스 외부) */
+
+/* 범례 오른쪽 라벨 */
 .legend-count {
     font-size: 15px;
     font-weight: bold;
-    color: #000; /* 원하는 색상(예: 검정) */
+    color: #000;
+}
+
+/* 리뷰 리스트 영역 */
+.reviews-container {
+    width: 850px;
+    max-height: 79%;
+    overflow-y: auto;
+    overflow-x: hidden;
+    margin-top: 40px;
+    margin-left: 8px;
+}
+
+.review-item {
+    display: flex;
+    flex-direction: column;
+    width: 830px;
+    min-height: 57px;
+    border: 1px solid #ccc;
+    border-radius: 15px;
+    padding: 5px 10px;
+    margin-bottom: 10px;
+    box-sizing: border-box;
+    background-color: #F3F3F3;
+    font-size: 15px;
+}
+
+.review-summary {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    margin-top: 12px;
+}
+
+.review-mode {
+    flex: 1;
+    font-weight: bold;
+    text-align: left;
+    margin-left: 40px;
+}
+
+/* 각 모드에 해당하는 색상 */
+.review-mode.clean {
+    color: #9E9E9E;
+}
+.review-mode.optimize {
+    color: #4CAF50;
+}
+.review-mode.newbie {
+    color: #2196F3;
+}
+.review-mode.study {
+    color: #FFC107;
+}
+.review-mode.basic {
+    color: #FF5722;
+}
+
+.review-link {
+    flex: 1.5;
+    margin-left: -180px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: left;
+}
+
+.review-date {
+    margin-right: 35px;
+}
+
+.review-arrow {
+    margin-right: 20px;
+    font-size: 18px;
 }

--- a/src/pages/History.jsx
+++ b/src/pages/History.jsx
@@ -6,25 +6,17 @@ import Reviews from '../components/Reviews/Reviews';
 
 const History = () => {
   const [selectedReview, setSelectedReview] = useState('');
-  const [selectedMode, setSelectedMode] = useState(''); 
-  // 검색어 상태
+  const [selectedMode, setSelectedMode] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
 
   const handleReviewClick = (content) => {
     setSelectedReview(content);
   };
 
-  // 차트에서 특정 모드 클릭 시 모드 토글
   const handleSliceClick = (mode) => {
-    if (selectedMode === mode) {
-      setSelectedMode(''); 
-    } else {
-      setSelectedMode(mode);
-    }
+    setSelectedMode(prevMode => (prevMode === mode ? '' : mode));
   };
 
-  // 컴포넌트 로드시 창 리사이즈 이벤트 발생
-  // (이로 인해 페이지의 박스 크기가 올바르게 재계산됩니다)
   useEffect(() => {
     window.dispatchEvent(new Event('resize'));
   }, []);
@@ -38,7 +30,6 @@ const History = () => {
       <div className="content-wrapper">
         <div className="left-container">
 
-          {/* 차트 영역 */}
           <div className="chart-box">
             <p className="box-title">Mode Statistics</p>
             <Chart onSliceClick={handleSliceClick} selectedMode={selectedMode} />
@@ -64,23 +55,14 @@ const History = () => {
             </div>
           </div>
 
-          {/* 리뷰 리스트 영역 */}
           <div className="reviewList-box">
             <p className="box-title">All reviews</p>
-
-            {/* 검색창 - SearchBar */}
             <div className="searchbar-container" style={{ width: '300px' }}>
-              {/*
-                value: 현재 검색어
-                onChange: 입력 변화 시 setSearchTerm
-              */}
               <SearchBar 
                 value={searchTerm} 
                 onChange={(e) => setSearchTerm(e.target.value)}
               />
             </div>
-
-            {/* 리뷰 목록 컴포넌트(검색어와 선택된 모드 전달) */}
             <Reviews 
               onReviewClick={handleReviewClick} 
               selectedMode={selectedMode}
@@ -88,8 +70,7 @@ const History = () => {
             />
           </div>
         </div>
-        
-        {/* 오른쪽 영역: 상세 리뷰 */}
+
         <div className="right-container">
           <div className="reviewDetails-box">
             <p className="box-title">Review</p>

--- a/src/pages/History.jsx
+++ b/src/pages/History.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import "./History.css";
 import Chart from '../components/Chart/Chart';
 import SearchBar from '../components/SearchBar/SearchBar';
@@ -6,13 +6,15 @@ import Reviews from '../components/Reviews/Reviews';
 
 const History = () => {
   const [selectedReview, setSelectedReview] = useState('');
-  const [selectedMode, setSelectedMode] = useState(''); // 선택된 모드 관리
+  const [selectedMode, setSelectedMode] = useState(''); 
+  // 검색어 상태
+  const [searchTerm, setSearchTerm] = useState('');
 
   const handleReviewClick = (content) => {
     setSelectedReview(content);
   };
 
-  // Chart에서 클릭 이벤트 발생 시 호출할 콜백 함수
+  // 차트에서 특정 모드 클릭 시 모드 토글
   const handleSliceClick = (mode) => {
     if (selectedMode === mode) {
       setSelectedMode(''); 
@@ -20,6 +22,12 @@ const History = () => {
       setSelectedMode(mode);
     }
   };
+
+  // 컴포넌트 로드시 창 리사이즈 이벤트 발생
+  // (이로 인해 페이지의 박스 크기가 올바르게 재계산됩니다)
+  useEffect(() => {
+    window.dispatchEvent(new Event('resize'));
+  }, []);
 
   return (
     <div className="history-container">
@@ -29,9 +37,10 @@ const History = () => {
 
       <div className="content-wrapper">
         <div className="left-container">
+
+          {/* 차트 영역 */}
           <div className="chart-box">
             <p className="box-title">Mode Statistics</p>
-            {/* Chart에 onSliceClick와 selectedMode 전달 */}
             <Chart onSliceClick={handleSliceClick} selectedMode={selectedMode} />
             <div className="chart-legend">
               {['BASIC', 'CLEAN', 'OPTIMIZE', 'NEWBIE', 'STUDY'].map((mode) => (
@@ -44,7 +53,8 @@ const History = () => {
                       mode === 'CLEAN' ? '#9E9E9E' :
                       mode === 'OPTIMIZE' ? '#4CAF50' :
                       mode === 'NEWBIE' ? '#2196F3' :
-                      mode === 'STUDY' ? '#FFC107' : '#ccc'
+                      mode === 'STUDY' ? '#FFC107' :
+                      '#ccc'
                     }}>
                     <span className="legend-label">{mode}</span>
                   </div>
@@ -53,16 +63,33 @@ const History = () => {
               ))}
             </div>
           </div>
+
+          {/* 리뷰 리스트 영역 */}
           <div className="reviewList-box">
             <p className="box-title">All reviews</p>
+
+            {/* 검색창 - SearchBar */}
             <div className="searchbar-container" style={{ width: '300px' }}>
-              <SearchBar />
+              {/*
+                value: 현재 검색어
+                onChange: 입력 변화 시 setSearchTerm
+              */}
+              <SearchBar 
+                value={searchTerm} 
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
             </div>
-            {/* Reviews에 selectedMode prop 전달 */}
-            <Reviews onReviewClick={handleReviewClick} selectedMode={selectedMode} />
-          </div>  
+
+            {/* 리뷰 목록 컴포넌트(검색어와 선택된 모드 전달) */}
+            <Reviews 
+              onReviewClick={handleReviewClick} 
+              selectedMode={selectedMode}
+              searchTerm={searchTerm}
+            />
+          </div>
         </div>
         
+        {/* 오른쪽 영역: 상세 리뷰 */}
         <div className="right-container">
           <div className="reviewDetails-box">
             <p className="box-title">Review</p>


### PR DESCRIPTION
### 🚀 Summary

페이지 디자인 디테일 수정 
---

### ✨ Description

영상 속 해상도는 1920 X 1200 입니다! (맥북에서는 1920 X 1080을 지원안해줘요....)

 # 대시보드 페이지
https://github.com/user-attachments/assets/2950aef1-d755-4f86-9c68-42f84d998ca6

모드선택 버튼 크기 및 디자인 피그마에 맞게 살짝 수정하고 등급 그래프에 더미데이터 몇개 추가해놨습니다

# 히스토리 페이지
https://github.com/user-attachments/assets/8ebf55d6-47fc-4093-84d6-d5fa401f6c02

기존에 애니메이션 효과가 계속해서 반복되는 오류 수정(페이지 처음 들어갈때만 애니메이션 나오게 구현), 검색창 기능구현(PR제목 기준으로 검색), 해상도에 맞게 컴포넌트들 배치


---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #28 
